### PR TITLE
Test for remove skipped action logic, api auth, main endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ cython_debug/
 
 # minikube
 .minikubevenv/
+
+# test resources
+test_session.cache

--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ ipdb = "==0.13.9"
 pydevd-pycharm = "*"
 factory-boy = "*"
 pytest-mock = "*"
+memcache = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ python-lorem = "*"
 flask-migrate = "*"
 psycopg2 = "*"
 requests = "*"
+helpers = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e91aff338dfd58c0b2adb6a1b7d782da46a0a0781c07f0f02878021725176b56"
+            "sha256": "e8fc0e45df21c349cf5b64dbc8bb3f0d0973905badb3bfd639a2d3dbe3ae1bcb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,19 +26,19 @@
         },
         "alembic": {
             "hashes": [
-                "sha256:9d33f3ff1488c4bfab1e1a6dfebbf085e8a8e1a3e047a43ad29ad1f67f012a1d",
-                "sha256:e3cab9e59778b3b6726bb2da9ced451c6622d558199fd3ef914f3b1e8f4ef704"
+                "sha256:7c328694a2e68f03ee971e63c3bd885846470373a5b532cf2c9f1601c413b153",
+                "sha256:a9dde941534e3d7573d9644e8ea62a2953541e27bc1793e166f60b777ae098b4"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.7.4"
+            "version": "==1.7.5"
         },
         "async-timeout": {
             "hashes": [
-                "sha256:7d87a4e8adba8ededb52e579ce6bc8276985888913620c935094c2276fd83382",
-                "sha256:f3303dddf6cafa748a92747ab6c2ecf60e0aeca769aee4c151adfce243a05d9b"
+                "sha256:a22c0b311af23337eb05fcf05a8b51c3ea53729d46fb5460af62bee033cec690",
+                "sha256:b930cb161a39042f9222f6efb7301399c87eeab394727ec5437924a36d6eef51"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.0.0"
+            "version": "==4.0.1"
         },
         "cachelib": {
             "hashes": [
@@ -337,28 +337,28 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:6d00e42d6d6289f8cd3e77618a01689d57a078fe324ee579b00fa206d32e9b07",
-                "sha256:bba1a940985c052c5cc7849f97da196ebc81f3b85ec10c56ef1f3228aa9cbe74"
+                "sha256:04438610bc6dadbdddb22a4a55bcc7f6f8099e69580b2e67f5a681933a1f4400",
+                "sha256:4c05c1684e0e97fe779c62b91878f173b937fe097b356cd82f793464f5bc6138"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.14.0"
+            "version": "==3.14.1"
         },
         "psycopg2": {
             "hashes": [
-                "sha256:079d97fc22de90da1d370c90583659a9f9a6ee4007355f5825e5f1c70dffc1fa",
-                "sha256:2087013c159a73e09713294a44d0c8008204d06326006b7f652bef5ace66eebb",
-                "sha256:25615574419dd9bda6fdfdcd58afb22e721f5b807cb3d5e62f488c8acf8cb754",
-                "sha256:2c992196719fadda59f72d44603ee1a2fdcc67de097eea38d41c7ad9ad246e62",
-                "sha256:7640e1e4d72444ef012e275e7b53204d7fab341fb22bc76057ede22fe6860b25",
-                "sha256:7f91312f065df517187134cce8e395ab37f5b601a42446bdc0f0d51773621854",
-                "sha256:830c8e8dddab6b6716a4bf73a09910c7954a92f40cf1d1e702fb93c8a919cc56",
-                "sha256:89409d369f4882c47f7ea20c42c5046879ce22c1e4ea20ef3b00a4dfc0a7f188",
-                "sha256:bf35a25f1aaa8a3781195595577fcbb59934856ee46b4f252f56ad12b8043bcf",
-                "sha256:de5303a6f1d0a7a34b9d40e4d3bef684ccc44a49bbe3eb85e3c0bffb4a131b7c",
-                "sha256:e5a8ed9dbfca8dc162c4ada5ab017e10d5a66c542b4c73569f103fa5f342f498"
+                "sha256:26322c3f114de1f60c1b0febf8fdd595c221b4f624524178f515d07350a71bd1",
+                "sha256:6796ac614412ce374587147150e56d03b7845c9e031b88aacdcadc880e81bb38",
+                "sha256:77b9105ef37bc005b8ffbcb1ed6d8685bb0e8ce84773738aa56421a007ec5a7a",
+                "sha256:77d09a79f9739b97099d2952bbbf18eaa4eaf825362387acbb9552ec1b3fa228",
+                "sha256:91c7fd0fe9e6c118e8ff5b665bc3445781d3615fa78e131d0b4f8c85e8ca9ec8",
+                "sha256:a761b60da0ecaf6a9866985bcde26327883ac3cdb90535ab68b8d784f02b05ef",
+                "sha256:a84da9fa891848e0270e8e04dcca073bc9046441eeb47069f5c0e36783debbea",
+                "sha256:b8816c6410fa08d2a022e4e38d128bae97c1855e176a00493d6ec62ccd606d57",
+                "sha256:dfc32db6ce9ecc35a131320888b547199f79822b028934bb5b332f4169393e15",
+                "sha256:f65cba7924363e0d2f416041b48ff69d559548f2cb168ff972c54e09e1e64db8",
+                "sha256:fd7ddab7d6afee4e21c03c648c8b667b197104713e57ec404d5b74097af21e31"
             ],
             "index": "pypi",
-            "version": "==2.9.1"
+            "version": "==2.9.2"
         },
         "python-lorem": {
             "hashes": [
@@ -378,11 +378,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:b03fa51273400cc0991d272cf77ac19b081837a87a5f1bf14ba3256bc3fbbd40",
-                "sha256:dfb6b7df2fabe198313d3a83103e0e5ff49ff7b262870cc3796f98d83283d2c6"
+                "sha256:7341184026de22b0aa80999904033a4a131771559ecde9a882ea1862b8ed435f",
+                "sha256:d10fdd7ffa0715626cb3101b5de346639ed0caa70b5b637512f19efaeeaac794"
             ],
             "index": "pypi",
-            "version": "==4.0.0rc2"
+            "version": "==4.0.0"
         },
         "requests": {
             "hashes": [
@@ -402,45 +402,45 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:07ac4461a1116b317519ddf6f34bcb00b011b5c1370ebeaaf56595504ffc7e84",
-                "sha256:090536fd23bf49077ee94ff97142bc5ee8bad24294c3d7c8d5284267c885dde7",
-                "sha256:1dee515578d04bc80c4f9a8c8cfe93f455db725059e885f1b1da174d91c4d077",
-                "sha256:1ef37c9ec2015ce2f0dc1084514e197f2f199d3dc3514190db7620b78e6004c8",
-                "sha256:295b90efef1278f27fe27d94a45460ae3c17f5c5c2b32c163e29c359740a1599",
-                "sha256:2ce42ad1f59eb85c55c44fb505f8854081ee23748f76b62a7f569cfa9b6d0604",
-                "sha256:2feb028dc75e13ba93456a42ac042b255bf94dbd692bf80b47b22653bb25ccf8",
-                "sha256:31f4426cfad19b5a50d07153146b2bcb372a279975d5fa39f98883c0ef0f3313",
-                "sha256:3c0c5f54560a92691d54b0768d67b4d3159e514b426cfcb1258af8c195577e8f",
-                "sha256:463ef692259ff8189be42223e433542347ae17e33f91c1013e9c5c64e2798088",
-                "sha256:4a882dedb9dfa6f33524953c3e3d72bcf518a5defd6d5863150a821928b19ad3",
-                "sha256:4c185c928e2638af9bae13acc3f70e0096eac76471a1101a10f96b80666b8270",
-                "sha256:5039faa365e7522a8eb4736a54afd24a7e75dcc33b81ab2f0e6c456140f1ad64",
-                "sha256:5c6774b34782116ad9bdec61c2dbce9faaca4b166a0bc8e7b03c2b870b121d94",
-                "sha256:6bc7f9d7d90ef55e8c6db1308a8619cd8f40e24a34f759119b95e7284dca351a",
-                "sha256:7e8ef103eaa72a857746fd57dda5b8b5961e8e82a528a3f8b7e2884d8506f0b7",
-                "sha256:7ef421c3887b39c6f352e5022a53ac18de8387de331130481cb956b2d029cad6",
-                "sha256:908fad32c53b17aad12d722379150c3c5317c422437e44032256a77df1746292",
-                "sha256:91efbda4e6d311812f23996242bad7665c1392209554f8a31ec6db757456db5c",
-                "sha256:a6506c17b0b6016656783232d0bdd03fd333f1f654d51a14d93223f953903646",
-                "sha256:a95bf9c725012dcd7ea3cac16bf647054e0d62b31d67467d228338e6a163e4ff",
-                "sha256:ad7e403fc1e3cb76e802872694e30d6ca6129b9bc6ad4e7caa48ca35f8a144f8",
-                "sha256:b86f762cee3709722ab4691981958cbec475ea43406a6916a7ec375db9cbd9e9",
-                "sha256:ba84026e84379326bbf2f0c50792f2ae56ab9c01937df5597b6893810b8ca369",
-                "sha256:bca660b76672e15d70a7dba5e703e1ce451a0257b6bd2028e62b0487885e8ae9",
-                "sha256:c24c01dcd03426a5fe5ee7af735906bec6084977b9027a3605d11d949a565c01",
-                "sha256:c2f2114b0968a280f94deeeaa31cfbac9175e6ac7bd3058b3ce6e054ecd762b3",
-                "sha256:c46f013ff31b80cbe36410281675e1fb4eaf3e25c284fd8a69981c73f6fa4cb4",
-                "sha256:c757ba1279b85b3460e72e8b92239dae6f8b060a75fb24b3d9be984dd78cfa55",
-                "sha256:cc6b21f19bc9d4cd77cbcba5f3b260436ce033f1053cea225b6efea2603d201e",
-                "sha256:dbf588ab09e522ac2cbd010919a592c6aae2f15ccc3cd9a96d01c42fbc13f63e",
-                "sha256:de996756d894a2d52c132742e3b6d64ecd37e0919ddadf4dc3981818777c7e67",
-                "sha256:e700d48056475d077f867e6a36e58546de71bdb6fdc3d34b879e3240827fefab",
-                "sha256:f1e97c5f36b94542f72917b62f3a2f92be914b2cf33b80fa69cede7529241d2a",
-                "sha256:fb2aa74a6e3c2cebea38dd21633671841fbe70ea486053cba33d68e3e22ccc0a",
-                "sha256:ff8f91a7b1c4a1c7772caa9efe640f2768828897044748f2458b708f1026e2d4"
+                "sha256:015511c52c650eebf1059ed8a21674d9d4ae567ebfd80fc73f8252faccd71864",
+                "sha256:0438bccc16349db2d5203598be6073175ce16d4e53b592d6e6cef880c197333e",
+                "sha256:10230364479429437f1b819a8839f1edc5744c018bfeb8d01320930f97695bc9",
+                "sha256:2146ef996181e3d4dd20eaf1d7325eb62d6c8aa4dc1677c1872ddfa8561a47d9",
+                "sha256:24828c5e74882cf41516740c0b150702bee4c6817d87d5c3d3bafef2e6896f80",
+                "sha256:2717ceae35e71de1f58b0d1ee7e773d3aab5c403c6e79e8d262277c7f7f95269",
+                "sha256:2e93624d186ea7a738ada47314701c8830e0e4b021a6bce7fbe6f39b87ee1516",
+                "sha256:435b1980c1333ffe3ab386ad28d7b209590b0fa83ea8544d853e7a22f957331b",
+                "sha256:486f7916ef77213103467924ef25f5ea1055ae901f385fe4d707604095fdf6a9",
+                "sha256:4ac8306e04275d382d6393e557047b0a9d7ddf9f7ca5da9b3edbd9323ea75bd9",
+                "sha256:4d1d707b752137e6bf45720648e1b828d5e4881d690df79cca07f7217ea06365",
+                "sha256:52f23a76544ed29573c0f3ee41f0ca1aedbab3a453102b60b540cc6fa55448ad",
+                "sha256:5beeff18b4e894f6cb73c8daf2c0d8768844ef40d97032bb187d75b1ec8de24b",
+                "sha256:6510f4a5029643301bdfe56b61e806093af2101d347d485c42a5535847d2c699",
+                "sha256:6afa9e4e63f066e0fd90a21db7e95e988d96127f52bfb298a0e9bec6999357a9",
+                "sha256:771eca9872b47a629010665ff92de1c248a6979b8d1603daced37773d6f6e365",
+                "sha256:78943451ab3ffd0e27876f9cea2b883317518b418f06b90dadf19394534637e9",
+                "sha256:8327e468b1775c0dfabc3d01f39f440585bf4d398508fcbbe2f0d931c502337d",
+                "sha256:8dbe5f639e6d035778ebf700be6d573f82a13662c3c2c3aa0f1dba303b942806",
+                "sha256:9134e5810262203388b203c2022bbcbf1a22e89861eef9340e772a73dd9076fa",
+                "sha256:9369f927f4d19b58322cfea8a51710a3f7c47a0e7f3398d94a4632760ecd74f6",
+                "sha256:987fe2f84ceaf744fa0e48805152abe485a9d7002c9923b18a4b2529c7bff218",
+                "sha256:a5881644fc51af7b232ab8d64f75c0f32295dfe88c2ee188023795cdbd4cf99b",
+                "sha256:a81e40dfa50ed3c472494adadba097640bfcf43db160ed783132045eb2093cb1",
+                "sha256:aadc6d1e58e14010ae4764d1ba1fd0928dbb9423b27a382ea3a1444f903f4084",
+                "sha256:ad8ec6b69d03e395db48df8991aa15fce3cd23e378b73e01d46a26a6efd5c26d",
+                "sha256:b02eee1577976acb4053f83d32b7826424f8b9f70809fa756529a52c6537eda4",
+                "sha256:bac949be7579fed824887eed6672f44b7c4318abbfb2004b2c6968818b535a2f",
+                "sha256:c035184af4e58e154b0977eea52131edd096e0754a88f7d5a847e7ccb3510772",
+                "sha256:c7d0a1b1258efff7d7f2e6cfa56df580d09ba29d35a1e3f604f867e1f685feb2",
+                "sha256:cc49fb8ff103900c20e4a9c53766c82a7ebbc183377fb357a8298bad216e9cdd",
+                "sha256:d768359daeb3a86644f3854c6659e4496a3e6bba2b4651ecc87ce7ad415b320c",
+                "sha256:d81c84c9d2523b3ea20f8e3aceea68615768a7464c0f9a9899600ce6592ec570",
+                "sha256:ec1c908fa721f2c5684900cc8ff75555b1a5a2ae4f5a5694eb0e37a5263cea44",
+                "sha256:fa52534076394af7315306a8701b726a6521b591d95e8f4e5121c82f94790e8d",
+                "sha256:fd421a14edf73cfe01e8f51ed8966294ee3b3db8da921cacc88e497fd6e977af"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.4.26"
+            "version": "==1.4.27"
         },
         "text-unidecode": {
             "hashes": [
@@ -451,11 +451,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
-                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
-                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
+                "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed",
+                "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"
             ],
-            "version": "==3.10.0.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.0"
         },
         "urllib3": {
             "hashes": [
@@ -637,11 +637,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:22e53b8082890cca9b595ec22f9b01676b9d96c5f2f1890bcb49e4d612aa40a2",
-                "sha256:810182ef3597e0dfc4999a29f7cf17b99c70b361aae0f16743de6b926619ae21"
+                "sha256:393bd1b5becf3ccbc04a4f0f13da7e437914b24cafd1a4d8b71b5fecff54fb34",
+                "sha256:876ba213aaddd661a539ada2158917c1be17064b72792ee788b81c13528865d0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==9.8.0"
+            "version": "==9.8.2"
         },
         "flake8": {
             "hashes": [
@@ -650,6 +650,13 @@
             ],
             "index": "pypi",
             "version": "==4.0.1"
+        },
+        "hashring": {
+            "hashes": [
+                "sha256:b3a4f78a51b80823565bb2132be9d60c98c79875006b7f47584a2c1e682e319f",
+                "sha256:f8498acc7fd0952a7e9a2cf6087ed33afbc96372d86eab705a836e31c4ede837"
+            ],
+            "version": "==1.5.1"
         },
         "iniconfig": {
             "hashes": [
@@ -695,6 +702,14 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "memcache": {
+            "hashes": [
+                "sha256:792a5e43ec1fd5c3ac597d4675dbc9516a49109cd890713527a754e857085909",
+                "sha256:ab75b674cc13ff5bb6f872668969a73b80e207d8499f4e6974cb05f3714f72f3"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0"
         },
         "packaging": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e8fc0e45df21c349cf5b64dbc8bb3f0d0973905badb3bfd639a2d3dbe3ae1bcb"
+            "sha256": "ecbd1d5606b6e9b9d1cbcf832fe14eb4513b9e829460cc962b7923c5d67890bc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -228,6 +228,14 @@
             "markers": "python_version >= '3' and platform_python_implementation == 'CPython' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
             "version": "==1.1.2"
         },
+        "helpers": {
+            "hashes": [
+                "sha256:2ca7fdfc5c1e6994f80e9d01812d92383163434372bad51e7c04d2fe04c82a3e",
+                "sha256:bdfe1641fdaa1be60de8d0a8e3d243e5273582969b1118e87895616f83acdf90"
+            ],
+            "index": "pypi",
+            "version": "==0.2.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
@@ -254,11 +262,11 @@
         },
         "mako": {
             "hashes": [
-                "sha256:169fa52af22a91900d852e937400e79f535496191c63712e3b9fda5a9bed6fc3",
-                "sha256:6804ee66a7f6a6416910463b00d76a7b25194cd27f1918500c5bd7be2a088a23"
+                "sha256:4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2",
+                "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.5"
+            "version": "==1.1.6"
         },
         "markupsafe": {
             "hashes": [
@@ -378,11 +386,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:7341184026de22b0aa80999904033a4a131771559ecde9a882ea1862b8ed435f",
-                "sha256:d10fdd7ffa0715626cb3101b5de346639ed0caa70b5b637512f19efaeeaac794"
+                "sha256:bc6832367d60e1a5f94d75314fc46e8ce6f07fee8e532ee1bfafaf4887f8b4bb",
+                "sha256:cc642f70e0ebddce960818ba35776af6a18487cc38f66deace68d55b97e6e3cf"
             ],
             "index": "pypi",
-            "version": "==4.0.0"
+            "version": "==4.0.1"
         },
         "requests": {
             "hashes": [
@@ -682,11 +690,11 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93",
-                "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"
+                "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d",
+                "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.18.0"
+            "version": "==0.18.1"
         },
         "matplotlib-inline": {
             "hashes": [
@@ -713,11 +721,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966",
-                "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==21.2"
+            "version": "==21.3"
         },
         "parso": {
             "hashes": [
@@ -783,10 +791,10 @@
         },
         "pydevd-pycharm": {
             "hashes": [
-                "sha256:aafe2acc737600f18d884454a29de2e589de3212b37b42848aca4b9fbb7111e4"
+                "sha256:f0d95505a5b7a247a418fe00eba975dd128dc4636b6cfc6b8d4f70990e7cb465"
             ],
             "index": "pypi",
-            "version": "==213.5605.23"
+            "version": "==213.5744.131"
         },
         "pyflakes": {
             "hashes": [
@@ -806,11 +814,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
         },
         "pytest": {
             "hashes": [

--- a/config.py
+++ b/config.py
@@ -24,6 +24,11 @@ class Config(object):
 class Testing(Config):
     TESTING = True
     DEBUG = False
+    SESSION_TYPE = 'filesystem'
+    SESSION_FILE_DIR = os.path.join(basedir, 'test_session.cache')
+    SESSION_FILE_THRESHOLD = 500
+    SESSION_FILE_MODE = 384
+
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'test.db')
     LOGGING_LEVEL = logging.WARNING
 

--- a/logic.py
+++ b/logic.py
@@ -10,7 +10,7 @@ def workflow_state_message(workflow, task_breadcrumbs, new_decision_action_id):
     if previous_task_id == new_decision_action_id:
         return {
             "level": "info",
-            "text": "Are you sure you have done this task. Looks like you haven't."
+            "text": "Are you sure you have done this task? Looks like you haven't."
         }
     elif previous_task_id in task_history_set:
         return {

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -6,10 +6,6 @@ from tests.helpers import ckan_client_test_double
 
 
 class TestLogin:
-    @pytest.fixture
-    def ckan_client_mock(self):
-        with patch('api.auth.ckan_client', wraps=ckan_client_test_double) as ckan_client_mock:
-            yield ckan_client_mock
 
     def test_login_with_valid_credentials(self, test_client, ckan_client_mock):
         r = test_client.post('login', json={"username": ckan_client_test_double.valid_username, "password": "pass"})

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,35 @@
+import pytest
+from flask import session
+
+from unittest.mock import patch
+from tests.helpers import ckan_client_test_double
+
+
+class TestLogin:
+    @pytest.fixture
+    def ckan_client_mock(self):
+        with patch('api.auth.ckan_client', wraps=ckan_client_test_double) as ckan_client_mock:
+            yield ckan_client_mock
+
+    def test_login_with_valid_credentials(self, test_client, ckan_client_mock):
+        r = test_client.post('login', json={"username": ckan_client_test_double.valid_username, "password": "pass"})
+
+        assert ckan_client_mock.authenticate_user.called
+        assert r.status_code == 200
+        assert r.json["message"] == "Login successful"
+
+    def test_login_with_invalid_credentials(self, test_client, ckan_client_mock):
+        r = test_client.post('login', json={"username": "invalid_username", "password": "pass"})
+
+        assert ckan_client_mock.authenticate_user.called
+        assert r.status_code == 401
+        assert r.json["message"] == "Bad credentials"
+
+    def test_login_stores_ckan_user_in_session(self, test_client, ckan_client_mock):
+        test_client.post('login', json={"username": ckan_client_test_double.valid_username, "password": "pass"})
+        assert session.get('ckan_user')
+
+    def test_logout_removes_ckan_user_from_session(self, test_client, ckan_client_mock):
+        test_client.post('login', json={"username": ckan_client_test_double.valid_username, "password": "pass"})
+        test_client.post('logout')
+        assert not session.get('ckan_user')

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -6,6 +6,10 @@ from tests.helpers import ckan_client_test_double
 
 
 class TestLogin:
+    @pytest.fixture()
+    def ckan_client_mock(self):
+        with patch('api.auth.ckan_client', wraps=ckan_client_test_double) as ckan_client_mock:
+            yield ckan_client_mock
 
     def test_login_with_valid_credentials(self, test_client, ckan_client_mock):
         r = test_client.post('login', json={"username": ckan_client_test_double.valid_username, "password": "pass"})

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,0 +1,39 @@
+import pytest
+
+class TestMain:
+    def test_index(self, test_client):
+        r = test_client.get('/')
+        assert r.status_code == 200
+        assert r.json
+
+    @pytest.mark.parametrize("endpoint_path,http_methods",
+                             [
+                                 ('/user', ['GET']),
+                                 ('/datasets', ['GET']),
+                                 ('/workflows', ['GET']),
+                                 ('/workflows/123/state', ['GET']),
+                                 ('/workflows/123/tasks/123', ['GET']),
+                                 ('/workflows/123/tasks/123/complete', ['POST', 'DELETE']),
+                                 ('/workflows/123/tasks/123/skip', ['POST', 'DELETE']),
+                             ])
+    def test_endpoint_require_logging_in(self, test_client, endpoint_path, http_methods):
+        for method in http_methods:
+            if method == 'POST':
+                r = test_client.post(endpoint_path)
+            elif method == 'DELETE':
+                r = test_client.delete(endpoint_path)
+            elif method == 'GET':
+                r = test_client.get(endpoint_path)
+            else:
+                pytest.fail(f"Unsupported http method {method}")
+            assert r.status_code == 401
+
+@pytest.mark.usefixtures('logged_in')
+class TestUserDataAvaiable:
+    def test_user_details(self, test_client):
+        r = test_client.get('/user')
+        assert r.status_code == 200
+        user_details = r.json
+        assert user_details['fullname'] == 'Fake CkanUser'
+        assert user_details['email'] == 'fake@fjelltopp.org'
+

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tests import factories
 from tests.helpers import ckan_client_test_double
 
 
@@ -64,3 +65,12 @@ class TestUserDataAvaiable:
         assert dataset['name']
         assert dataset['organizationName']
 
+    def test_workflow_list_returns_all_item_details(self, test_client, user):
+        factories.WorklowFactory.create_batch(10, user_id=ckan_client_test_double.valid_user_id)
+        r = test_client.get('/workflows')
+        assert r.status_code == 200
+        workflows = r.json['workflows']
+        assert len(workflows) == 10
+        for workflow in workflows:
+            assert workflow['id']
+            assert workflow['name']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,13 +20,18 @@ def user():
 
 @pytest.fixture(scope="session")
 def test_app():
-    app = create_app('config.Testing')
-    with app.app_context():
-        yield app
+    return create_app('config.Testing')
+
+
+@pytest.fixture(scope="session")
+def test_client(test_app):
+    with test_app.test_client() as client:
+        yield client
 
 
 @pytest.fixture(autouse=True, scope="session")
 def setup(test_app):
-    model.db.create_all()
-    yield
-    model.db.drop_all()
+    with test_app.app_context():
+        model.db.create_all()
+        yield
+        model.db.drop_all()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,15 @@ def user():
     return User(id=str(uuid.uuid4()))
 
 
-@pytest.fixture(autouse=True, scope="session")
-def setup():
+@pytest.fixture(scope="session")
+def test_app():
     app = create_app('config.Testing')
     with app.app_context():
-        model.db.create_all()
-        yield
-        model.db.drop_all()
+        yield app
+
+
+@pytest.fixture(autouse=True, scope="session")
+def setup(test_app):
+    model.db.create_all()
+    yield
+    model.db.drop_all()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,12 +40,7 @@ def setup(test_app):
         model.db.drop_all()
 
 
-@pytest.fixture(scope="session")
-def ckan_client_mock():
-    with patch('api.auth.ckan_client', wraps=ckan_client_test_double) as ckan_client_mock:
-        yield ckan_client_mock
-
-
 @pytest.fixture
-def logged_in(test_client, ckan_client_mock):
-    test_client.post('/login', json={"username": ckan_client_test_double.valid_username, "password": "pass"})
+def logged_in(test_client):
+    with patch('api.auth.ckan_client', wraps=ckan_client_test_double):
+        test_client.post('/login', json={"username": ckan_client_test_double.valid_username, "password": "pass"})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import uuid
 
 import pytest
@@ -6,6 +8,7 @@ import model
 from api.auth import User
 from app import create_app
 from tests import factories
+from tests.helpers import ckan_client_test_double
 
 
 @pytest.fixture()
@@ -35,3 +38,14 @@ def setup(test_app):
         model.db.create_all()
         yield
         model.db.drop_all()
+
+
+@pytest.fixture(scope="session")
+def ckan_client_mock():
+    with patch('api.auth.ckan_client', wraps=ckan_client_test_double) as ckan_client_mock:
+        yield ckan_client_mock
+
+
+@pytest.fixture
+def logged_in(test_client, ckan_client_mock):
+    test_client.post('/login', json={"username": ckan_client_test_double.valid_username, "password": "pass"})

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -9,6 +9,7 @@ class WorklowFactory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_get_or_create = ('dataset_id', 'user_id')
         sqlalchemy_session_persistence = 'commit'
     id = factory.Sequence(lambda n: int(n))
+    name = factory.Faker('name')
     decision_engine_id = factory.Faker('uuid4')
     dataset_id = factory.Faker('uuid4')
     user_id = factory.Faker('uuid4')

--- a/tests/helpers/ckan_client_test_double.py
+++ b/tests/helpers/ckan_client_test_double.py
@@ -1,0 +1,21 @@
+valid_username = 'fjelltopp_user'
+
+
+def authenticate_user(password, username):
+    if username == valid_username:
+        return {
+            "email_hash": "0e774ad846b368575ab7ca8738d114d",
+            "about": "Stubbed CKAN user",
+            "apikey": "46b76277-a274-433f-9b61-7b8085a1ce6f",
+            "display_name": "Tomasz Sabala",
+            "name": "tomek",
+            "created": "2019-09-18T08:34:32.156325",
+            "image_display_url": "",
+            "id": "a3418c4d-62a0-5d26-89ba-01ba0f6057f0",
+            "state": "active",
+            "image_url": "",
+            "fullname": "Fake CkanUser",
+            "email": "fake@fjelltopp.org",
+            "number_created_packages": 1
+        }
+    return {}

--- a/tests/helpers/ckan_client_test_double.py
+++ b/tests/helpers/ckan_client_test_double.py
@@ -1,6 +1,7 @@
 from clients.ckan_client import init_ckan, NotFound  # noqa: F401
 
 valid_username = 'fjelltopp_user'
+valid_user_id = "fake_user_id"
 
 
 def authenticate_user(password, username):
@@ -13,7 +14,7 @@ def authenticate_user(password, username):
             "name": "tomek",
             "created": "2019-09-18T08:34:32.156325",
             "image_display_url": "",
-            "id": "a3418c4d-62a0-5d26-89ba-01ba0f6057f0",
+            "id": valid_user_id,
             "state": "active",
             "image_url": "",
             "fullname": "Fake CkanUser",

--- a/tests/helpers/ckan_client_test_double.py
+++ b/tests/helpers/ckan_client_test_double.py
@@ -1,4 +1,4 @@
-from clients.ckan_client import NotFound
+from clients.ckan_client import init_ckan, NotFound  # noqa: F401
 
 valid_username = 'fjelltopp_user'
 
@@ -24,15 +24,24 @@ def authenticate_user(password, username):
 
 
 def fetch_country_estimates_datasets(ckan_cli):
-    pass
+    return [
+        {
+            "id": f"dataset_{i}",
+            "title": f"Dataset {i}",
+            "organization": {
+                "id": f"org_{i}",
+                "title": f"Organization {i}"
+            }
+        } for i in range(1, 6)
+    ]
 
 
 def fetch_user_organization_ids(ckan_cli, capacity="editor"):
-    pass
+    return ["org_1"]
 
 
 def fetch_user_collabolator_ids(ckan_cli, ckan_user_id=None, capacity="editor"):
-    pass
+    return ["dataset_5"]
 
 
 def fetch_dataset_details(ckan_cli, dataset_id):
@@ -49,4 +58,3 @@ def push_workflow_state(ckan_cli, dataset_id, workflow_state):
 
 def dataset_show_url(ckan_cli, dataset_id):
     pass
-

--- a/tests/helpers/ckan_client_test_double.py
+++ b/tests/helpers/ckan_client_test_double.py
@@ -1,3 +1,5 @@
+from clients.ckan_client import NotFound
+
 valid_username = 'fjelltopp_user'
 
 
@@ -19,3 +21,32 @@ def authenticate_user(password, username):
             "number_created_packages": 1
         }
     return {}
+
+
+def fetch_country_estimates_datasets(ckan_cli):
+    pass
+
+
+def fetch_user_organization_ids(ckan_cli, capacity="editor"):
+    pass
+
+
+def fetch_user_collabolator_ids(ckan_cli, ckan_user_id=None, capacity="editor"):
+    pass
+
+
+def fetch_dataset_details(ckan_cli, dataset_id):
+    pass
+
+
+def fetch_workflow_state(ckan_cli, dataset_id):
+    pass
+
+
+def push_workflow_state(ckan_cli, dataset_id, workflow_state):
+    pass
+
+
+def dataset_show_url(ckan_cli, dataset_id):
+    pass
+

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,33 @@
+import pytest
+
+import logic
+import model
+
+
+@pytest.mark.parametrize("skipped_tasks,skipped_tasks_to_remove,expected",
+                         [
+                             ([f"task_{n}" for n in range(1, 6)], [f"task_{n}" for n in range(4, 6)],
+                              [f"task_{n}" for n in range(1, 4)]),
+                             ([f"task_{n}" for n in range(1, 4)], ["task_2"], ["task_1", "task_3"]),
+                             ([f"task_{n}" for n in range(1, 6)], ["task_1"], [f"task_{n}" for n in range(2, 6)]),
+                             ([f"task_{n}" for n in range(1, 6)], [f"task_{n}" for n in range(1, 6)], []),
+                             ([f"task_{n}" for n in range(1, 6)], [], [f"task_{n}" for n in range(1, 6)]),
+                             ([f"task_{n}" for n in range(1, 6)], ["not_skipped"], [f"task_{n}" for n in range(1, 6)]),
+                         ],
+                         ids=[
+                             "unskipp last two actions",
+                             "unskipp action from the middle",
+                             "unskipp first action",
+                             "unskipp all actions",
+                             "unskipp no actions",
+                             "unskipp actions not skipped"
+                         ]
+                         )
+def test_remove_tasks_from_skipped_list(workflow, skipped_tasks, skipped_tasks_to_remove, expected):
+    workflow.skipped_tasks = skipped_tasks
+
+    logic.remove_tasks_from_skipped_list(workflow, skipped_tasks_to_remove)
+
+    expected_set = set(expected)
+    actual = set(model.Workflow.query.get(workflow.id).skipped_tasks)
+    assert actual == expected_set

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -4,6 +4,28 @@ import logic
 import model
 
 
+@pytest.mark.parametrize("task_breadcrumbs,task_id,last_engine_decision_id,expected_message",
+                         [
+                             ([f"task_{n}" for n in range(1, 6)], "task_5", "task_4", ""),
+                             ([f"task_{n}" for n in range(1, 6)], "task_5", "task_5",
+                              "Are you sure you have done this task? Looks like you haven't."),
+                             ([f"task_{n}" for n in range(1, 6)], "task_5", "task_2",
+                              "You need to deal with a previous task."),
+                         ],
+                         ids=[
+                             "no message for next, consequitve task",
+                             "info message for the same task twice",
+                             "info message if task from the past"
+                         ]
+                         )
+def test_workflow_state_message(workflow, task_breadcrumbs, task_id, last_engine_decision_id, expected_message):
+    workflow.last_engine_decision_id = last_engine_decision_id
+    message = logic.workflow_state_message(workflow, task_breadcrumbs, task_id) or {}
+    actual = message.get("text", "")
+
+    assert expected_message in actual
+
+
 @pytest.mark.parametrize("skipped_tasks,skipped_tasks_to_remove,expected",
                          [
                              ([f"task_{n}" for n in range(1, 6)], [f"task_{n}" for n in range(4, 6)],


### PR DESCRIPTION
This PR:
1. Cleans up the test flask app init in pytest.fixtures
2. Sets up filesystem storage for flask sessions for tests
3. Creates tests for remove skipped action logic
4. Creates tests for api auth endpoint with help of ckan_client test double.
5. Creates tests for api main endpoint for /user, /datasets, /workflows