### PR TITLE
NAV-275 Navigator fails after login with auth0 if user hasn't logged in to ADR first

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -29,8 +29,7 @@ def user_details():
             }
         )
     except ckan_client.NotFound:
-        return error.not_found("Couldn't find user details in ADR. Does the user have ADR account?")
-
+        return "user_not_found_in_adr"
 
 @api_bp.route('/datasets')
 @auth0_service.require_auth(None)

--- a/api/routes.py
+++ b/api/routes.py
@@ -2,7 +2,6 @@ import logging
 
 from flask import Blueprint, jsonify
 
-from api import error
 from api.auth import auth0_service
 from clients import ckan_client
 
@@ -30,6 +29,7 @@ def user_details():
         )
     except ckan_client.NotFound:
         return "user_not_found_in_adr"
+
 
 @api_bp.route('/datasets')
 @auth0_service.require_auth(None)


### PR DESCRIPTION
NAV-275 Very crude way of informing user that have never logged into ADR before to log before using Navigator

