### PR TITLE
NAV-280 make Auth0Service happy that AUTH0_ISSUER_BASE_URL starts with the protocol already

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -35,11 +35,10 @@ class Auth0Service:
 
 class Auth0JWTBearerTokenValidator(JWTBearerTokenValidator):
     """Auth0 Validator to be used in Auth0Service"""
-    def __init__(self, domain, audience):
-        issuer = f"https://{domain}/"
-        jsonurl = urlopen(f"{issuer}.well-known/jwks.json")
+    def __init__(self, issuer, audience):
+        json_url = urlopen(f"{issuer}.well-known/jwks.json")
         public_key = JsonWebKey.import_key_set(
-            json.loads(jsonurl.read())
+            json.loads(json_url.read())
         )
         super(Auth0JWTBearerTokenValidator, self).__init__(
             public_key

--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ class Config(object):
     SENTRY_DSN = os.getenv("SENTRY_DSN")
     LANGUAGES = os.getenv('NAVIGATOR_LANGUAGES', 'en,fr,pt').split(',')
     DEFAULT_LANGUAGE = os.getenv('NAVIGATOR_DEFAULT_LANGUAGE', 'en')
-    AUTH0_ISSUER_BASE_URL = os.getenv('AUTH0_ISSUER_BASE_URL', 'hivtools.eu.auth0.com')
+    AUTH0_ISSUER_BASE_URL = os.getenv('AUTH0_ISSUER_BASE_URL', 'https://hivtools.eu.auth0.com/')
     AUTH0_AUDIENCE = os.getenv('AUTH0_AUDIENCE', 'http://navigator.minikube')
     AUTH0_EMAIL_NAMESPACE = os.getenv('AUTH0_EMAIL_NAMESPACE', 'http://navigator.minikube/email')
 
@@ -28,8 +28,6 @@ class Config(object):
 class Testing(Config):
     TESTING = True
     DEBUG = False
-
-    AUTH0_EMAIL_NAMESPACE = 'http://navigator.minikube/email'
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'test.db')
     LOGGING_LEVEL = logging.WARNING
 


### PR DESCRIPTION
As it says on the tin - I was accidentally duplicating the protocol after #51 and this was causing the pod to fail on deploy

Please also review fjelltopp/fjelltopp-infrastructure#167